### PR TITLE
fix: Replace deprecated splat expression with [*] for Terraform 1.5.6…

### DIFF
--- a/src/kms.tf
+++ b/src/kms.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "kms_key_rds" {
       type = "AWS"
 
       identifiers = [
-        format("arn:${join("", data.aws_partition.current.*.partition)}:iam::%s:root", join("", data.aws_caller_identity.current.*.account_id))
+        format("arn:%s:iam::%s:root", join("", data.aws_partition.current[*].partition), join("", data.aws_caller_identity.current[*].account_id))
       ]
     }
   }


### PR DESCRIPTION
## Terraform 0.12.0+ Splat Operator Updates
## What
Updated Terraform configuration to replace legacy splat syntax 

> (resource.*.attribute)

 with modern bracket-based expressions` (resource[*].attribute).`
Incorporated for expressions where applicable to improve flexibility and readability.
No functional changes to infrastructure; these updates are syntax improvements.
## Why
Aligns with Terraform 0.12.0+ enhancements and first-class expression support.
Improves readability and maintainability of Terraform code.
Prevents potential deprecation warnings by replacing outdated syntax.
## References
[Terraform v0.12.0 Upgrade Guide](https://developer.hashicorp.com/terraform/language/v1.2.x/expressions/splat)


