### PR TITLE
fix: update legacy splat operator

### DIFF
--- a/src/kms.tf
+++ b/src/kms.tf
@@ -5,7 +5,7 @@ module "kms_key_rds" {
   description             = "KMS key for Aurora Postgres"
   deletion_window_in_days = 10
   enable_key_rotation     = true
-  policy                  = join("", data.aws_iam_policy_document.kms_key_rds.*.json)
+  policy                  = join("", data.aws_iam_policy_document.kms_key_rds[*].json)
 
   context = module.cluster.context
 }


### PR DESCRIPTION
## what

 - Updated the syntax for accessing elements in a list from `data.aws_iam_policy_document.kms_key_rds.*.json` to `data.aws_iam_policy_document.kms_key_rds[*].json`.

## why

- Enhance code consistency by addressing TFLint errors
- `*.` (splat operator) is an older syntax that returns a list but is not always well-typed. The newer explicit splat syntax is more consistent and predictable when accessing lists

## references

- [TFLint Rules](https://github.com/terraform-linters/tflint-ruleset-terraform/tree/main/docs/rules)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Refined internal configuration handling to align with current Terraform standards.
	- The update enhances code maintainability without altering any user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->