### PR TITLE
feat: expose security group ID for Aurora Postgres cluster

### DIFF
--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -67,3 +67,8 @@ output "allowed_security_groups" {
   value       = local.allowed_security_groups
   description = "The resulting list of security group IDs that are allowed to connect to the Aurora Postgres cluster."
 }
+
+output "security_group_id" {
+  value       = module.aurora_postgres_cluster.security_group_id
+  description = "The security group ID of the Aurora Postgres cluster"
+}


### PR DESCRIPTION
## what
- Add security_group_id output to expose the security group ID from the underlying RDS cluster module

## why
- This enables proper configuration of inbound and outbound traffic rules for ECS services

## references
.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Terraform output that exposes the security group ID of the Aurora Postgres cluster. This makes it easier to reference the cluster’s security group in downstream configurations (e.g., networking rules or integrations). No changes to existing outputs or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->