### PR TITLE
Allow passing allowed security groups by id

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -10,7 +10,7 @@ locals {
     for eks in module.eks :
     eks.outputs.eks_cluster_managed_security_group_id
   ]
-  allowed_security_groups = concat(data.aws_security_groups.allowed.ids, local.allowed_eks_security_groups)
+  allowed_security_groups = concat(data.aws_security_groups.allowed.ids, local.allowed_eks_security_groups, var.allowed_security_group_ids)
 
   zone_id = module.dns_gbl_delegated.outputs.default_dns_zone_id
 

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -275,6 +275,12 @@ variable "allowed_security_group_names" {
   default     = []
 }
 
+variable "allowed_security_group_ids" {
+  type        = list(string)
+  description = "List of security group ids that should be allowed access to the database"
+  default     = []
+}
+
 variable "eks_security_group_enabled" {
   type        = bool
   description = "Use the eks default security group"


### PR DESCRIPTION
## what
* Allows passing security groups by id

## why
* The security group name is not available from the output of other components; this change provides flexibility to provide either the name or id depending on availability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an optional configuration to specify additional security group IDs, expanding the set of allowed security groups alongside the existing name-based option.
  * Enhances flexibility for access control by allowing both name- and ID-based configuration.
  * Backward compatible: if not set, behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->