### PR TITLE
Update engine version in serverless.yaml

### DIFF
--- a/test/fixtures/stacks/catalog/usecase/basic.yaml
+++ b/test/fixtures/stacks/catalog/usecase/basic.yaml
@@ -19,7 +19,7 @@ components:
 
         # Provisioned configuration
         engine_mode: provisioned
-        engine_version: "15.14"
+        engine_version: "15.13"
         cluster_family: aurora-postgresql15
         # 1 writer, 1 reader
         cluster_size: 2

--- a/test/fixtures/stacks/catalog/usecase/basic.yaml
+++ b/test/fixtures/stacks/catalog/usecase/basic.yaml
@@ -19,7 +19,7 @@ components:
 
         # Provisioned configuration
         engine_mode: provisioned
-        engine_version: "15.3"
+        engine_version: "15.14"
         cluster_family: aurora-postgresql15
         # 1 writer, 1 reader
         cluster_size: 2

--- a/test/fixtures/stacks/catalog/usecase/serverless.yaml
+++ b/test/fixtures/stacks/catalog/usecase/serverless.yaml
@@ -20,7 +20,7 @@ components:
         # Serverless v2 configuration
         engine_mode: provisioned
         instance_type: "db.serverless" # serverless engine_mode ignores `var.instance_type`
-        engine_version: "13.22" # Latest supported version as of 08/28/2023
+        engine_version: "13.21" # Latest supported version as of 08/28/2023
         cluster_family: aurora-postgresql13
         cluster_size: 1
          # serverless

--- a/test/fixtures/stacks/catalog/usecase/serverless.yaml
+++ b/test/fixtures/stacks/catalog/usecase/serverless.yaml
@@ -20,7 +20,7 @@ components:
         # Serverless v2 configuration
         engine_mode: provisioned
         instance_type: "db.serverless" # serverless engine_mode ignores `var.instance_type`
-        engine_version: "13.15" # Latest supported version as of 08/28/2023
+        engine_version: "13.22" # Latest supported version as of 08/28/2023
         cluster_family: aurora-postgresql13
         cluster_size: 1
          # serverless


### PR DESCRIPTION
## what
* Update engine version in serverless.yaml

## why
* `13.15` is EOL on AWS

## references
* https://linear.app/cloudposse/issue/DEV-3640/decommission-aurora-postgresql-cluster-in-sandbox-aws-799847381734-us


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated default Aurora PostgreSQL engine versions in configuration templates: provisioned to 15.13 and serverless to 13.21.
  - Aligns templates with supported releases for improved compatibility and security; no behavioral or logic changes.

- Tests
  - Updated test fixtures to reflect the new engine versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->