### PR TITLE
feat: support RDS-managed admin password via Secrets Manager

### DIFF
--- a/src/cluster-regional.tf
+++ b/src/cluster-regional.tf
@@ -16,7 +16,7 @@ module "aurora_postgres_cluster" {
   cluster_size               = var.cluster_size
   promotion_tier             = var.promotion_tier
   admin_user                 = local.admin_user
-  admin_password             = var.manage_admin_user_password ? null : local.admin_password
+  admin_password             = local.admin_password
   manage_admin_user_password = var.manage_admin_user_password
 
   db_name                              = local.database_name

--- a/src/cluster-regional.tf
+++ b/src/cluster-regional.tf
@@ -16,7 +16,7 @@ module "aurora_postgres_cluster" {
   cluster_size               = var.cluster_size
   promotion_tier             = var.promotion_tier
   admin_user                 = local.admin_user
-  admin_password             = var.manage_admin_user_password != null ? null : local.admin_password
+  admin_password             = var.manage_admin_user_password ? null : local.admin_password
   manage_admin_user_password = var.manage_admin_user_password
 
   db_name                              = local.database_name

--- a/src/cluster-regional.tf
+++ b/src/cluster-regional.tf
@@ -7,16 +7,17 @@ module "aurora_postgres_cluster" {
   source  = "cloudposse/rds-cluster/aws"
   version = "2.1.1"
 
-  cluster_type   = "regional"
-  engine         = var.engine
-  engine_version = var.engine_version
-  engine_mode    = var.engine_mode
-  cluster_family = var.cluster_family
-  instance_type  = var.instance_type
-  cluster_size   = var.cluster_size
-  promotion_tier = var.promotion_tier
-  admin_user     = local.admin_user
-  admin_password = local.admin_password
+  cluster_type               = "regional"
+  engine                     = var.engine
+  engine_version             = var.engine_version
+  engine_mode                = var.engine_mode
+  cluster_family             = var.cluster_family
+  instance_type              = var.instance_type
+  cluster_size               = var.cluster_size
+  promotion_tier             = var.promotion_tier
+  admin_user                 = local.admin_user
+  admin_password             = var.manage_admin_user_password != null ? null : local.admin_password
+  manage_admin_user_password = var.manage_admin_user_password
 
   db_name                              = local.database_name
   publicly_accessible                  = var.publicly_accessible

--- a/src/main.tf
+++ b/src/main.tf
@@ -18,7 +18,7 @@ locals {
   # 2. If admin_password is provided, that value is used (manage_admin_user_password must be false)
   # 3. If both are unset/false/empty, the module creates a random password
   create_password = local.enabled && var.admin_password == "" && !var.manage_admin_user_password
-  admin_password  = local.create_password ? one(random_password.admin_password[*].result) : var.admin_password
+  admin_password  = var.manage_admin_user_password ? null : (local.create_password ? one(random_password.admin_password[*].result) : var.admin_password)
 
   admin_user    = length(var.admin_user) > 0 ? var.admin_user : join("", random_pet.admin_user[*].id)
   database_name = length(var.database_name) > 0 ? var.database_name : join("", random_pet.database_name[*].id)

--- a/src/main.tf
+++ b/src/main.tf
@@ -20,8 +20,8 @@ locals {
   create_password = local.enabled && var.admin_password == "" && !var.manage_admin_user_password
   admin_password  = var.manage_admin_user_password ? null : (local.create_password ? one(random_password.admin_password[*].result) : var.admin_password)
 
-  admin_user    = length(var.admin_user) > 0 ? var.admin_user : join("", random_pet.admin_user[*].id)
-  database_name = length(var.database_name) > 0 ? var.database_name : join("", random_pet.database_name[*].id)
+  admin_user    = length(var.admin_user) > 0 ? var.admin_user : one(random_pet.admin_user[*].id)
+  database_name = length(var.database_name) > 0 ? var.database_name : one(random_pet.database_name[*].id)
 
   cluster_dns_name_prefix = format("%v%v%v%v", module.this.name, module.this.delimiter, var.cluster_name, module.this.delimiter)
   cluster_dns_name        = format("%v%v", local.cluster_dns_name_prefix, var.cluster_dns_name_part)

--- a/src/main.tf
+++ b/src/main.tf
@@ -14,9 +14,9 @@ locals {
 
   zone_id = module.dns_gbl_delegated.outputs.default_dns_zone_id
 
-  # 1. If manage_admin_user_password is not null, AWS manages the password (admin_password must be null)
-  # 2. If admin_password is provided, that value is used (manage_admin_user_password must be null)
-  # 3. If both are null, the module creates a random password
+  # 1. If manage_admin_user_password is true, AWS manages the password (admin_password must be empty)
+  # 2. If admin_password is provided, that value is used (manage_admin_user_password must be false)
+  # 3. If both are unset/false/empty, the module creates a random password
   create_password = local.enabled && var.admin_password == "" && var.manage_admin_user_password == null
   admin_password  = local.create_password ? one(random_password.admin_password[*].result) : var.admin_password
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -17,7 +17,7 @@ locals {
   # 1. If manage_admin_user_password is true, AWS manages the password (admin_password must be empty)
   # 2. If admin_password is provided, that value is used (manage_admin_user_password must be false)
   # 3. If both are unset/false/empty, the module creates a random password
-  create_password = local.enabled && var.admin_password == "" && var.manage_admin_user_password == null
+  create_password = local.enabled && var.admin_password == "" && !var.manage_admin_user_password
   admin_password  = local.create_password ? one(random_password.admin_password[*].result) : var.admin_password
 
   admin_user    = length(var.admin_user) > 0 ? var.admin_user : join("", random_pet.admin_user[*].id)

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -122,6 +122,13 @@ variable "admin_password" {
   }
 }
 
+variable "manage_admin_user_password" {
+  type        = bool
+  default     = false
+  nullable    = false
+  description = "Set to true to allow RDS to manage the master user password in Secrets Manager. Cannot be set if admin_password is provided"
+}
+
 # https://aws.amazon.com/rds/aurora/pricing
 variable "instance_type" {
   type        = string

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -125,8 +125,8 @@ variable "admin_password" {
 variable "manage_admin_user_password" {
   type        = bool
   default     = false
-  nullable    = false
   description = "Set to true to allow RDS to manage the master user password in Secrets Manager. Cannot be set if admin_password is provided"
+  nullable    = false
 }
 
 # https://aws.amazon.com/rds/aurora/pricing


### PR DESCRIPTION
## what

This pull request introduces support for allowing AWS RDS to manage the admin user password for Aurora PostgreSQL clusters via Secrets Manager, while maintaining backward compatibility with the existing manual password management. The changes clarify and enforce the logic for how admin passwords are set, ensuring only one method is used at a time, and update the relevant variables and local values accordingly.

**Password management enhancements:**

* Added a new variable `manage_admin_user_password` to enable AWS-managed admin passwords via Secrets Manager, with validation to prevent conflicts if `admin_password` is also provided. (`src/variables.tf` [src/variables.tfR125-R131](diffhunk://#diff-e64d396480ef61e94c68b45e4940f63bdb28cce844c90404d648122910254904R125-R131))
* Updated local logic to ensure only one password management method is active: AWS-managed, user-provided, or auto-generated, and set `admin_password` accordingly. (`src/main.tf` [src/main.tfR17-L18](diffhunk://#diff-1956abf05e8db0150fc12428093f137d1e9cca0a1d2d780a890c054274fb1e30R17-L18))
* Modified the Aurora cluster module configuration to pass the correct values for `admin_password` and the new `manage_admin_user_password` parameter, ensuring compatibility with the new logic. (`src/cluster-regional.tf` [src/cluster-regional.tfL19-R20](diffhunk://#diff-ea95c29a2830e786b5e9878f875e011795282451c8132278b224cd5b03e5cd01L19-R20))

## why

* Add `manage_admin_user_password` variable to allow AWS RDS to manage the master user password in Secrets Manager. Adjust logic to ensure `admin_password` and `manage_admin_user_password` are mutually exclusive, and update module and locals to support this new option. This enhances security and flexibility for password management.

## references

* [TF Docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#manage_master_user_password-1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to let the database service manage the admin password in Secrets Manager; when enabled the admin password may be left unset.
  * Admin username, password, and database name can be auto-generated when not provided.

* **Documentation**
  * Clarified password-management rules and evaluation order: service-managed, user-provided, or auto-generated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->