### PR TITLE
feat(terraform): add `database_insights_mode` variable

### DIFF
--- a/src/cluster-regional.tf
+++ b/src/cluster-regional.tf
@@ -5,7 +5,7 @@
 # https://www.terraform.io/docs/providers/aws/r/rds_cluster.html
 module "aurora_postgres_cluster" {
   source  = "cloudposse/rds-cluster/aws"
-  version = "2.2.0"
+  version = "2.3.0"
 
   cluster_type               = "regional"
   engine                     = var.engine
@@ -39,6 +39,7 @@ module "aurora_postgres_cluster" {
   enhanced_monitoring_role_enabled     = var.enhanced_monitoring_role_enabled
   enhanced_monitoring_attributes       = var.enhanced_monitoring_attributes
   performance_insights_enabled         = var.performance_insights_enabled
+  database_insights_mode               = var.database_insights_mode
   rds_monitoring_interval              = var.rds_monitoring_interval
   autoscaling_enabled                  = var.autoscaling_enabled
   autoscaling_policy_type              = var.autoscaling_policy_type

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -198,11 +198,6 @@ variable "database_insights_mode" {
   type        = string
   description = "The database insights mode for the RDS cluster. Valid values are `standard`, `advanced`. See https://registry.terraform.io/providers/hashicorp/aws/6.16.0/docs/resources/rds_cluster#database_insights_mode-1"
   default     = null
-
-  validation {
-    condition     = contains(["standard", "advanced"], var.database_insights_mode)
-    error_message = "Allowed values: `standard`, `advanced`."
-  }
 }
 
 variable "enhanced_monitoring_role_enabled" {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -194,6 +194,17 @@ variable "performance_insights_enabled" {
   description = "Whether to enable Performance Insights"
 }
 
+variable "database_insights_mode" {
+  type        = string
+  description = "The database insights mode for the RDS cluster. Valid values are `standard`, `advanced`. See https://registry.terraform.io/providers/hashicorp/aws/6.16.0/docs/resources/rds_cluster#database_insights_mode-1"
+  default     = null
+
+  validation {
+    condition     = contains(["standard", "advanced"], var.database_insights_mode)
+    error_message = "Allowed values: `standard`, `advanced`."
+  }
+}
+
 variable "enhanced_monitoring_role_enabled" {
   type        = bool
   description = "A boolean flag to enable/disable the creation of the enhanced monitoring IAM role. If set to `false`, the module will not create a new role and will use `rds_monitoring_role_arn` for enhanced monitoring"


### PR DESCRIPTION
## what

- Upgrade rds-cluster module to v2.3.0 and introduce the database_insights_mode variable to support configuring RDS cluster insights mode. Adds validation for allowed values ("standard", "advanced") and updates module usage accordingly.

## why

This pull request updates the Aurora PostgreSQL cluster module and adds support for configuring the `database_insights_mode` for RDS clusters. The main changes introduce a new variable to control the insights mode and update the module version to ensure compatibility.

## references

- [Module Update](https://github.com/cloudposse/terraform-aws-rds-cluster/pull/274/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR382-R383)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Aurora PostgreSQL cluster module to v2.3.0.

* **New Features**
  * Added a configurable "database insights mode" option (supports "standard" and "advanced") to select the level of RDS database monitoring and insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->