### PR TITLE
feat: add optional RDS DB Proxy support

### DIFF
--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -133,3 +133,8 @@ output "proxy_iam_role_arn" {
   value       = one(module.rds_proxy[*].proxy_iam_role_arn)
   description = "The ARN of the IAM role that the proxy uses to access secrets in AWS Secrets Manager"
 }
+
+output "proxy_security_group_id" {
+  value       = one(aws_security_group.proxy[*].id)
+  description = "The security group ID of the RDS Proxy"
+}

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -72,3 +72,64 @@ output "security_group_id" {
   value       = module.aurora_postgres_cluster.security_group_id
   description = "The security group ID of the Aurora Postgres cluster"
 }
+
+# RDS Proxy Outputs
+output "proxy_id" {
+  value       = one(module.rds_proxy[*].proxy_id)
+  description = "The ID of the RDS Proxy"
+}
+
+output "proxy_arn" {
+  value       = one(module.rds_proxy[*].proxy_arn)
+  description = "The ARN of the RDS Proxy"
+}
+
+output "proxy_endpoint" {
+  value       = one(module.rds_proxy[*].proxy_endpoint)
+  description = "The endpoint of the RDS Proxy"
+}
+
+output "proxy_dns_name" {
+  value       = one(aws_route53_record.proxy[*].fqdn)
+  description = "The DNS name of the RDS Proxy (Route53 record)"
+}
+
+output "proxy_target_endpoint" {
+  value       = one(module.rds_proxy[*].proxy_target_endpoint)
+  description = "Hostname for the target RDS DB Instance"
+}
+
+output "proxy_target_id" {
+  value       = one(module.rds_proxy[*].proxy_target_id)
+  description = "Identifier of db_proxy_name, target_group_name, target type, and resource identifier separated by forward slashes"
+}
+
+output "proxy_target_port" {
+  value       = one(module.rds_proxy[*].proxy_target_port)
+  description = "Port for the target Aurora DB cluster"
+}
+
+output "proxy_target_rds_resource_id" {
+  value       = one(module.rds_proxy[*].proxy_target_rds_resource_id)
+  description = "Identifier representing the DB cluster target"
+}
+
+output "proxy_target_type" {
+  value       = one(module.rds_proxy[*].proxy_target_type)
+  description = "Type of target (e.g. RDS_INSTANCE or TRACKED_CLUSTER)"
+}
+
+output "proxy_default_target_group_arn" {
+  value       = one(module.rds_proxy[*].proxy_default_target_group_arn)
+  description = "The Amazon Resource Name (ARN) representing the default target group"
+}
+
+output "proxy_default_target_group_name" {
+  value       = one(module.rds_proxy[*].proxy_default_target_group_name)
+  description = "The name of the default target group"
+}
+
+output "proxy_iam_role_arn" {
+  value       = one(module.rds_proxy[*].proxy_iam_role_arn)
+  description = "The ARN of the IAM role that the proxy uses to access secrets in AWS Secrets Manager"
+}

--- a/src/proxy.tf
+++ b/src/proxy.tf
@@ -39,13 +39,6 @@ module "rds_proxy" {
 
   db_cluster_identifier = module.aurora_postgres_cluster.cluster_identifier
 
-  lifecycle {
-    precondition {
-      condition     = contains(["mysql", "postgresql", "sqlserver"], var.engine)
-      error_message = "RDS Proxy only supports MYSQL, POSTGRESQL, and SQLSERVER engine families. The engine '${var.engine}' is not supported."
-    }
-  }
-
   auth                         = local.proxy_auth
   engine_family                = local.proxy_engine_family
   vpc_subnet_ids               = var.publicly_accessible ? local.public_subnet_ids : local.private_subnet_ids
@@ -73,4 +66,11 @@ resource "aws_route53_record" "proxy" {
   type    = "CNAME"
   ttl     = 60
   records = [module.rds_proxy[0].proxy_endpoint]
+}
+
+check "proxy_engine_supported" {
+  assert {
+    condition     = !var.proxy_enabled || contains(["mysql", "postgresql", "sqlserver"], var.engine)
+    error_message = "RDS Proxy only supports MYSQL, POSTGRESQL, and SQLSERVER engine families. The engine '${var.engine}' is not supported."
+  }
 }

--- a/src/proxy.tf
+++ b/src/proxy.tf
@@ -76,9 +76,10 @@ module "rds_proxy" {
 
   db_cluster_identifier = module.aurora_postgres_cluster.cluster_identifier
 
-  auth                         = local.proxy_auth
-  engine_family                = local.proxy_engine_family
-  vpc_subnet_ids               = var.publicly_accessible ? local.public_subnet_ids : local.private_subnet_ids
+  auth          = local.proxy_auth
+  engine_family = local.proxy_engine_family
+  # RDS Proxy must always be in private subnets for security
+  vpc_subnet_ids               = local.private_subnet_ids
   vpc_security_group_ids       = [aws_security_group.proxy[0].id]
   debug_logging                = var.proxy_debug_logging
   idle_client_timeout          = var.proxy_idle_client_timeout

--- a/src/proxy.tf
+++ b/src/proxy.tf
@@ -1,0 +1,66 @@
+locals {
+  proxy_enabled = local.enabled && var.proxy_enabled
+
+  # Determine engine family for proxy based on the engine variable
+  proxy_engine_family = var.engine == "postgresql" ? "POSTGRESQL" : (
+    var.engine == "mysql" ? "MYSQL" : upper(var.engine)
+  )
+
+  # Get the secret ARN for authentication - either from managed password or user-provided
+  # When manage_admin_user_password is true, the cluster creates a secret in Secrets Manager
+  proxy_secret_arn = var.manage_admin_user_password ? module.aurora_postgres_cluster.admin_user_secret[0].secret_arn : var.proxy_secret_arn
+
+  # Build auth configuration
+  proxy_auth = var.proxy_auth != null ? var.proxy_auth : (
+    local.proxy_secret_arn != null ? [
+      {
+        auth_scheme               = "SECRETS"
+        client_password_auth_type = var.proxy_client_password_auth_type
+        description               = "Authenticate using Secrets Manager"
+        iam_auth                  = var.proxy_iam_auth
+        secret_arn                = local.proxy_secret_arn
+        username                  = null
+      }
+    ] : []
+  )
+
+  # Proxy DNS name
+  proxy_dns_name = format("%v%v", local.cluster_dns_name_prefix, var.proxy_dns_name_part)
+}
+
+module "rds_proxy" {
+  source  = "cloudposse/rds-db-proxy/aws"
+  version = "1.1.1"
+
+  count = local.proxy_enabled ? 1 : 0
+
+  db_cluster_identifier = module.aurora_postgres_cluster.cluster_identifier
+
+  auth                         = local.proxy_auth
+  engine_family                = local.proxy_engine_family
+  vpc_subnet_ids               = var.publicly_accessible ? local.public_subnet_ids : local.private_subnet_ids
+  vpc_security_group_ids       = [module.aurora_postgres_cluster.security_group_id]
+  debug_logging                = var.proxy_debug_logging
+  idle_client_timeout          = var.proxy_idle_client_timeout
+  require_tls                  = var.proxy_require_tls
+  connection_borrow_timeout    = var.proxy_connection_borrow_timeout
+  init_query                   = var.proxy_init_query
+  max_connections_percent      = var.proxy_max_connections_percent
+  max_idle_connections_percent = var.proxy_max_idle_connections_percent
+  session_pinning_filters      = var.proxy_session_pinning_filters
+  iam_role_attributes          = var.proxy_iam_role_attributes
+  existing_iam_role_arn        = var.proxy_existing_iam_role_arn
+  kms_key_id                   = var.storage_encrypted ? module.kms_key_rds.key_arn : null
+
+  context = module.cluster.context
+}
+
+resource "aws_route53_record" "proxy" {
+  count = local.proxy_enabled && var.proxy_dns_enabled ? 1 : 0
+
+  zone_id = local.zone_id
+  name    = local.proxy_dns_name
+  type    = "CNAME"
+  ttl     = 60
+  records = [module.rds_proxy[0].proxy_endpoint]
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -450,13 +450,23 @@ variable "proxy_init_query" {
 variable "proxy_max_connections_percent" {
   type        = number
   default     = 100
-  description = "The maximum size of the connection pool for each target in a target group"
+  description = "The maximum size of the connection pool for each target in a target group. Must be between 1 and 100."
+
+  validation {
+    condition     = var.proxy_max_connections_percent >= 1 && var.proxy_max_connections_percent <= 100
+    error_message = "proxy_max_connections_percent must be between 1 and 100 (inclusive)."
+  }
 }
 
 variable "proxy_max_idle_connections_percent" {
   type        = number
   default     = 50
-  description = "Controls how actively the proxy closes idle database connections in the connection pool"
+  description = "Controls how actively the proxy closes idle database connections in the connection pool. Must be between 0 and 100."
+
+  validation {
+    condition     = var.proxy_max_idle_connections_percent >= 0 && var.proxy_max_idle_connections_percent <= 100
+    error_message = "proxy_max_idle_connections_percent must be between 0 and 100 (inclusive)."
+  }
 }
 
 variable "proxy_session_pinning_filters" {


### PR DESCRIPTION
## Summary
Adds optional RDS DB Proxy module integration with automatic engine family detection, managed password support via Secrets Manager, Route53 DNS records, and SSM parameter exports. Includes comprehensive proxy configuration variables and outputs.

## Changes
- New `proxy.tf` with RDS Proxy module (v1.1.1) and Route53 DNS integration
- 17 new variables for complete proxy configuration with input validation
- 12 new outputs exposing proxy endpoints, IDs, and IAM role information
- SSM parameters for proxy endpoint and hostname (with DNS fallback)

## PR #46 Compatibility
Auth block structure includes `client_password_auth_type` and `username` fields from the released v1.1.1 module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RDS Proxy integration with configurable connection pooling, auth, TLS, and DNS options
  * Optional Route 53 DNS record for proxy endpoints
  * Proxy endpoint/host written to SSM Parameter Store when enabled
  * Security group and network rules added to allow proxy–cluster traffic
  * New outputs exposing proxy details (IDs, ARNs, endpoints, DNS, target info, default target group, IAM role)
  * Validation added to enforce supported engine types when proxy is enabled

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->