### PR TITLE
feat: add storage_type passthrough variable

### DIFF
--- a/src/cluster-regional.tf
+++ b/src/cluster-regional.tf
@@ -32,6 +32,7 @@ module "aurora_postgres_cluster" {
   allowed_cidr_blocks                  = local.allowed_cidr_blocks
   iam_database_authentication_enabled  = var.iam_database_authentication_enabled
   storage_encrypted                    = var.storage_encrypted
+  storage_type                         = var.storage_type
   kms_key_arn                          = var.storage_encrypted ? module.kms_key_rds.key_arn : null
   performance_insights_kms_key_id      = var.performance_insights_enabled ? module.kms_key_rds.key_arn : null
   maintenance_window                   = var.maintenance_window

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -43,6 +43,12 @@ variable "storage_encrypted" {
   description = "Specifies whether the DB cluster is encrypted"
 }
 
+variable "storage_type" {
+  type        = string
+  default     = null
+  description = "One of 'standard' (magnetic), 'gp2' (general purpose SSD), 'io1' (provisioned IOPS SSD), 'aurora', or 'aurora-iopt1'"
+}
+
 variable "engine" {
   type        = string
   description = "Name of the database engine to be used for the DB cluster"


### PR DESCRIPTION
## Summary
• Add `storage_type` variable that passes through to the underlying RDS cluster module
• Allows users to specify storage type options: 'standard', 'gp2', 'io1', 'aurora', or 'aurora-iopt1'
• Variable uses same name, type, default value, and description as the submodule

## Test plan
- [ ] Verify Terraform plan shows no unexpected changes with default (null) value
- [ ] Test with different storage_type values to ensure proper passthrough
- [ ] Confirm variable validation and documentation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable storage type parameter for Aurora PostgreSQL clusters, supporting standard, gp2, io1, aurora, and aurora-iopt1 storage options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->