### PR TITLE
feat: Allow overriding Performance Insights KMS key

### DIFF
--- a/src/cluster-regional.tf
+++ b/src/cluster-regional.tf
@@ -34,7 +34,7 @@ module "aurora_postgres_cluster" {
   storage_encrypted                    = var.storage_encrypted
   storage_type                         = var.storage_type
   kms_key_arn                          = var.storage_encrypted ? module.kms_key_rds.key_arn : null
-  performance_insights_kms_key_id      = var.performance_insights_enabled ? module.kms_key_rds.key_arn : null
+  performance_insights_kms_key_id      = var.performance_insights_enabled ? coalesce(var.performance_insights_kms_key_arn, module.kms_key_rds.key_arn) : null
   maintenance_window                   = var.maintenance_window
   enabled_cloudwatch_logs_exports      = var.enabled_cloudwatch_logs_exports
   enhanced_monitoring_role_enabled     = var.enhanced_monitoring_role_enabled

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -200,6 +200,12 @@ variable "performance_insights_enabled" {
   description = "Whether to enable Performance Insights"
 }
 
+variable "performance_insights_kms_key_arn" {
+  type        = string
+  default     = null
+  description = "ARN of the KMS key for Performance Insights encryption. If null, defaults to the RDS CMK."
+}
+
 variable "database_insights_mode" {
   type        = string
   description = "The database insights mode for the RDS cluster. Valid values are `standard`, `advanced`. See https://registry.terraform.io/providers/hashicorp/aws/6.16.0/docs/resources/rds_cluster#database_insights_mode-1"


### PR DESCRIPTION
## What

Add a `performance_insights_kms_key_arn` variable to allow users to specify a custom KMS key ARN for Performance Insights encryption. When `null` (default), the component falls back to the existing RDS CMK — preserving current behavior.

## Why

If the cluster already has a PI KMS key assigned by AWS (typically the default `aws/rds` managed key — e.g. from a prior manual enablement or a partially applied change), AWS rejects the modification with:

```
InvalidParameterCombination: You can't change your Performance Insights KMS key.
```

This is because **Performance Insights KMS keys are immutable after cluster creation**. There is currently no way to tell the component to use a different key, forcing users to work around this with lifecycle ignore rules or manual state manipulation.

## Changes

- **`src/variables.tf`**: New `performance_insights_kms_key_arn` variable (`string`, default `null`)
- **`src/cluster-regional.tf`**: Use `coalesce(var.performance_insights_kms_key_arn, module.kms_key_rds.key_arn)` so the override takes precedence when set

## Usage

```hcl
# Use the AWS-managed key already assigned to an existing cluster
performance_insights_kms_key_arn: "arn:aws:kms:eu-west-1:123456789012:key/abcd1234-5678-90ab-cdef-example11111"
```

Generated with Claude Opus 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom KMS key management for Performance Insights encryption. Users can now provide their own KMS key ARN, with automatic fallback to the default RDS-managed key when not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->