### PR TITLE
fix: Guard contains() against null in proxy_client_password_auth_type validation

### DIFF
--- a/src/variables.tf
+++ b/src/variables.tf
@@ -538,7 +538,7 @@ variable "proxy_client_password_auth_type" {
   description = "The type of authentication the proxy uses for connections from clients. Valid values: MYSQL_NATIVE_PASSWORD, POSTGRES_SCRAM_SHA_256, POSTGRES_MD5, SQL_SERVER_AUTHENTICATION"
 
   validation {
-    condition     = var.proxy_client_password_auth_type == null || contains(["MYSQL_NATIVE_PASSWORD", "POSTGRES_SCRAM_SHA_256", "POSTGRES_MD5", "SQL_SERVER_AUTHENTICATION"], var.proxy_client_password_auth_type)
+    condition     = var.proxy_client_password_auth_type == null ? true : contains(["MYSQL_NATIVE_PASSWORD", "POSTGRES_SCRAM_SHA_256", "POSTGRES_MD5", "SQL_SERVER_AUTHENTICATION"], var.proxy_client_password_auth_type)
     error_message = "Valid values for proxy_client_password_auth_type are: MYSQL_NATIVE_PASSWORD, POSTGRES_SCRAM_SHA_256, POSTGRES_MD5, SQL_SERVER_AUTHENTICATION."
   }
 }


### PR DESCRIPTION
## What

Replace `||` with a ternary in the `proxy_client_password_auth_type` variable validation to prevent `contains()` from receiving a `null` argument.

## Why

On OpenTofu <1.10 (confirmed on v1.9.1), the `||` operator does not short-circuit evaluation. When `proxy_client_password_auth_type` is `null` (the default), both sides of the `||` are evaluated, and `contains()` receives `null` as its second argument, causing:

```
Error: Invalid function argument

  on variables.tf line 549, in variable "proxy_client_password_auth_type":
    │ while calling contains(list, value)
    │ var.proxy_client_password_auth_type is null

Invalid value for "value" parameter: argument must not be null.
```

This means **any user on OpenTofu <1.10 who has not set `proxy_client_password_auth_type` will hit a plan failure** with the current default of `null`.

## Fix

```diff
- condition = var.proxy_client_password_auth_type == null || contains([...], var.proxy_client_password_auth_type)
+ condition = var.proxy_client_password_auth_type == null ? true : contains([...], var.proxy_client_password_auth_type)
```

The ternary guarantees `contains()` is never called when the value is `null`.

Generated with Claude Opus 4.6